### PR TITLE
Do not break dexterity content type when we don't have a REQUEST

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,6 +5,10 @@ Changelog
 1.1 (unreleased)
 ----------------
 
+- Do not break dexterity content type when we don't have a REQUEST 
+  (in async context).
+  [thomasdesvenain]
+
 - We can add contact and contact list fields TTW on dexterity content types.
   [thomasdesvenain]
 

--- a/src/collective/contact/widget/factory.py
+++ b/src/collective/contact/widget/factory.py
@@ -74,7 +74,8 @@ class ContactTypesVocabulary(object):
 
         site = getSite()
         ttool = getToolByName(site, 'portal_types')
+        request = getattr(site, 'REQUEST', None)
         return SimpleVocabulary([SimpleTerm(contact_type,
                            token=contact_type,
-                           title=translate(ttool[contact_type].Title(), context=site.REQUEST))
+                           title=translate(ttool[contact_type].Title(), context=request))
                 for contact_type in contact_types])


### PR DESCRIPTION
  (in async context).
