### PR TITLE
Fix an exception with plone.formwidget.contenttree >= 1.0.9.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,7 +4,8 @@ Changelog
 1.6 (unreleased)
 ----------------
 
-- Nothing changed yet.
+- Fix an exception with plone.formwidget.contenttree >= 1.0.9.
+  [pcdummy]
 
 
 1.5 (2016-03-04)

--- a/src/collective/contact/widget/source.py
+++ b/src/collective/contact/widget/source.py
@@ -60,14 +60,18 @@ class ContactSource(ObjPathSource):
 
     relations = None
 
-    def __init__(self, context, selectable_filter, navigation_tree_query=None):
+    def __init__(self, context, selectable_filter, navigation_tree_query=None,
+                 default=None, defaultFactory=None, **kw):
         """relations params is a dictionary : {relation_name: related_to_path}
         it filters on all results that have a relation with the content
         """
         selectable_filter = deepcopy(selectable_filter)
         if 'relations' in selectable_filter.criteria:
             self.relations = selectable_filter.criteria.pop('relations')[0]
-        super(ContactSource, self).__init__(context, selectable_filter, navigation_tree_query)
+        super(ContactSource, self).__init__(
+            context, selectable_filter, navigation_tree_query,
+            default, defaultFactory, **kw
+        )
         portal_url = getToolByName(getSite(), 'portal_url')
         self.portal_url = portal_url()
         self.portal_path = portal_url.getPortalPath()


### PR DESCRIPTION
We got exceptions with newer versions of Plone which ship plone.formwidget.contenttree 1.0.13.

    2016-03-15 15:16:53 INFO Zope Ready to handle requests
    2016-03-15 15:17:16 ERROR Zope.SiteErrorLog 1458051436.770.439159072236 http://plone.local:8081/demo/contacts/janedoe/plone-member/@@edit
    Traceback (innermost last):
      Module ZPublisher.Publish, line 138, in publish
      Module ZPublisher.mapply, line 77, in mapply
      Module Products.PDBDebugMode.runcall, line 70, in pdb_runcall
      Module ZPublisher.Publish, line 48, in call_object
      Module plone.z3cform.layout, line 66, in __call__
      Module plone.z3cform.layout, line 50, in update
      Module plone.dexterity.browser.edit, line 64, in update
      Module plone.z3cform.fieldsets.extensible, line 59, in update
      Module plone.z3cform.patch, line 30, in GroupForm_update
      Module z3c.form.group, line 132, in update
      Module z3c.form.form, line 136, in updateWidgets
      Module z3c.form.field, line 277, in update
      Module z3c.formwidget.query.widget, line 112, in update
      Module collective.contact.widget.widgets, line 100, in bound_source
      Module z3c.formwidget.query.widget, line 99, in bound_source
      Module z3c.formwidget.query.widget, line 94, in source
      Module zope.schema._field, line 349, in bind
      Module plone.formwidget.contenttree.source, line 275, in __call__
    TypeError: __init__() got an unexpected keyword argument 'default'
    > /home/pcdummy/.buildout/eggs/plone.formwidget.contenttree-1.0.13-py2.7.egg/plone/formwidget/contenttree/source.py(275)__call__()
    -> defaultFactory=self.defaultFactory)


This Pull Request fixes that.

Signed-off-by: Rene Jochum <rene@jochums.at>