### PR TITLE
Set Content-type 'text/plain' headers to autocomplete request.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,7 +4,8 @@ Changelog
 1.10 (unreleased)
 -----------------
 
-- Nothing changed yet.
+- Set Content-type 'text/plain' headers to autocomplete request. This prevent "<!DOCTYPE html" tag.
+  [bsuttor]
 
 
 1.9 (2017-05-30)
@@ -186,4 +187,3 @@ Changelog
 
 - Initial release.
   [vincentfretin]
-

--- a/src/collective/contact/widget/widgets.py
+++ b/src/collective/contact/widget/widgets.py
@@ -233,5 +233,8 @@ class AutocompleteSearch(BaseAutocompleteSearch):
         if getattr(source, 'do_post_sort', True):
             terms = sorted(set(terms), key=lambda t: t.title)
 
+        response = self.request.response
+        response.setHeader('Content-type', 'text/plain')
+
         return u'\n'.join([u"|".join((t.token, t.title or t.token, t.portal_type, t.url, t.extra))
                           for t in terms])


### PR DESCRIPTION
It prevents <! DOCTYPE html> tag.