### PR TITLE
Add prefiltering to contact list widget

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -17,8 +17,8 @@ You can add contact fields to your schema, like this ::
 
 		manager = ContactList(
 	        title=_(u"Project Manager"),
-	        source=ContactSourceBinder(portal_type=("held_position",),
-	                                   relations={'position': '/contacts/ecreall'}),
+	        value_type=ContactChoice(source=ContactSourceBinder(portal_type=("held_position",),
+	                                                            relations={'position': '/contacts/ecreall'})),
 	        )
 
 Example code means that 'manager' is a multi-valued contact field which

--- a/README.rst
+++ b/README.rst
@@ -15,7 +15,7 @@ You can add contact fields to your schema, like this ::
             source=ContactSourceBinder(portal_type=("organization",),
             )
 
-		manager = ContactChoice(
+		manager = ContactList(
 	        title=_(u"Project Manager"),
 	        source=ContactSourceBinder(portal_type=("held_position",),
 	                                   relations={'position': '/contacts/ecreall'}),
@@ -25,6 +25,17 @@ Example code means that 'manager' is a multi-valued contact field which
 vocabulary gets held_position objects of site.
 The vocabulary is restricted to objects that have a 'position' relation to '/contacts/ecreall' object
 (i.e. which are held_positions in ecreall company).
+
+You can add another filtering option like this
+	    company = ContactChoice(
+            title=_(u"Company"),
+            source=ContactSourceBinder(portal_type=("organization",),
+            prefilter_vocabulary='vocabulary or source',
+            prefilter_default_value='context aware method',
+            )
+
+The prefilter vocabulary is displayed in the widget. The user can select a specific directory by example.
+Each term value contains a criteria, like u'{"path": "/Plone/directory1"}' (beware to use " in dict !).
 
 If you run this javascript expression :
 
@@ -41,8 +52,8 @@ This product has been translated into
 
 - French.
 
-You can contribute for any message missing or other new languages, join us at 
-`Plone Collective Team <https://www.transifex.com/plone/plone-collective/>`_ 
+You can contribute for any message missing or other new languages, join us at
+`Plone Collective Team <https://www.transifex.com/plone/plone-collective/>`_
 into *Transifex.net* service with all world Plone translators community.
 
 

--- a/src/collective/contact/widget/locales/collective.contact.widget.pot
+++ b/src/collective/contact/widget/locales/collective.contact.widget.pot
@@ -21,7 +21,11 @@ msgstr ""
 msgid "(nothing)"
 msgstr ""
 
-#: ../factory.py:35
+#: ../templates/contact_input.pt:8
+msgid "Choose a filter:"
+msgstr ""
+
+#: ../factory.py:36
 msgid "Contact"
 msgstr ""
 
@@ -39,6 +43,11 @@ msgstr ""
 
 #: ../widgets.py:94
 msgid "Fill your search here..."
+msgstr ""
+
+
+#: ../templates/contact_input.pt:10
+msgid "No filter"
 msgstr ""
 
 #: ../interfaces.py:43

--- a/src/collective/contact/widget/locales/collective.contact.widget.pot
+++ b/src/collective/contact/widget/locales/collective.contact.widget.pot
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2014-03-18 07:34+0000\n"
+"POT-Creation-Date: 2020-09-11 09:39+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -17,12 +17,8 @@ msgstr ""
 "Preferred-Encodings: utf-8 latin1\n"
 "Domain: collective.contact.widget\n"
 
-#: ../widgets.py:73
+#: ../widgets.py:90
 msgid "(nothing)"
-msgstr ""
-
-#: ../templates/contact_input.pt:8
-msgid "Choose a filter:"
 msgstr ""
 
 #: ../factory.py:36
@@ -33,7 +29,7 @@ msgstr ""
 msgid "Contact content types that should be provided by autocompletion"
 msgstr ""
 
-#: ../factory.py:37
+#: ../factory.py:38
 msgid "Contact list"
 msgstr ""
 
@@ -41,13 +37,16 @@ msgstr ""
 msgid "Contact types"
 msgstr ""
 
-#: ../widgets.py:94
+#: ../widgets.py:136
 msgid "Fill your search here..."
 msgstr ""
 
+#: ../templates/contact_input.pt:8
+msgid "Filter:"
+msgstr ""
 
-#: ../templates/contact_input.pt:10
-msgid "No filter"
+#: ../configure.zcml:22
+msgid "Installs the collective.contact.widget package"
 msgstr ""
 
 #: ../interfaces.py:43
@@ -58,12 +57,10 @@ msgstr ""
 msgid "Review states that should be visible"
 msgstr ""
 
-#. Default: "If the item doesn't exist, you can add it to the database :"
-#: ../templates/contact_input.pt:17
-msgid "help_widget_add_new_elt"
+#: ../configure.zcml:22
+msgid "collective.contact.widget"
 msgstr ""
 
-#: ../widgets.py:32
+#: ../widgets.py:49
 msgid "please wait"
 msgstr ""
-

--- a/src/collective/contact/widget/locales/es/LC_MESSAGES/collective.contact.widget.po
+++ b/src/collective/contact/widget/locales/es/LC_MESSAGES/collective.contact.widget.po
@@ -3,27 +3,27 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: collective.contact.widget\n"
-"POT-Creation-Date: 2014-03-18 07:34+0000\n"
+"POT-Creation-Date: 2020-09-11 09:39+0000\n"
 "PO-Revision-Date: 2020-04-28 09:50-0400\n"
 "Last-Translator: Leonardo J. Caballero G. <leonardocaballero@gmail.com>\n"
 "Language-Team: ES <LL@li.org>\n"
-"Language: es\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
-"X-Generator: Virtaal 0.7.1\n"
 "Language-Code: es\n"
 "Language-Name: Spanish\n"
 "Preferred-Encodings: utf-8 latin1\n"
 "Domain: collective.contact.widget\n"
+"Language: es\n"
+"X-Generator: Virtaal 0.7.1\n"
 "X-Is-Fallback-For: es-ar es-bo es-cl es-co es-cr es-do es-ec es-es es-sv es-gt es-hn es-mx es-ni es-pa es-py es-pe es-pr es-us es-uy es-ve\n"
 
-#: ../widgets.py:73
+#: ../widgets.py:90
 msgid "(nothing)"
 msgstr "(ninguno)"
 
-#: ../factory.py:35
+#: ../factory.py:36
 msgid "Contact"
 msgstr "Contacto"
 
@@ -31,7 +31,7 @@ msgstr "Contacto"
 msgid "Contact content types that should be provided by autocompletion"
 msgstr "Tipos de contenido de contacto que se pueden ofrecer por el autocompletado"
 
-#: ../factory.py:37
+#: ../factory.py:38
 msgid "Contact list"
 msgstr "Lista de contactos"
 
@@ -39,9 +39,17 @@ msgstr "Lista de contactos"
 msgid "Contact types"
 msgstr "Tipos de contactos"
 
-#: ../widgets.py:94
+#: ../widgets.py:136
 msgid "Fill your search here..."
 msgstr "Saisissez votre recherche..."
+
+#: ../templates/contact_input.pt:8
+msgid "Filter:"
+msgstr ""
+
+#: ../configure.zcml:22
+msgid "Installs the collective.contact.widget package"
+msgstr ""
 
 #: ../interfaces.py:43
 msgid "Review states"
@@ -51,11 +59,10 @@ msgstr "Estados de flujo de trabajo"
 msgid "Review states that should be visible"
 msgstr "Estados de flujo de trabajo que debería esta visible"
 
-#. Default: "If the item doesn't exist, you can add it to the database :"
-#: ../templates/contact_input.pt:17
-msgid "help_widget_add_new_elt"
-msgstr "Si el elemento no existe, usted puede añadirlo a la base de datos :"
+#: ../configure.zcml:22
+msgid "collective.contact.widget"
+msgstr ""
 
-#: ../widgets.py:32
+#: ../widgets.py:49
 msgid "please wait"
 msgstr "por favor, sea paciente, espero un poco"

--- a/src/collective/contact/widget/locales/fr/LC_MESSAGES/collective.contact.widget.po
+++ b/src/collective/contact/widget/locales/fr/LC_MESSAGES/collective.contact.widget.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: collective.contact.widget\n"
-"POT-Creation-Date: 2014-03-18 07:34+0000\n"
+"POT-Creation-Date: 2020-09-11 09:39+0000\n"
 "PO-Revision-Date: 2014-03-18 08:34+0100\n"
 "Last-Translator: Cédric Messiant <cedric.messiant@gmail.com>\n"
 "Language-Team: French\n"
@@ -15,13 +15,9 @@ msgstr ""
 "Domain: collective.contact.widget\n"
 "X-Generator: Poedit 1.5.4\n"
 
-#: ../widgets.py:73
+#: ../widgets.py:90
 msgid "(nothing)"
 msgstr "(aucune)"
-
-#: ../templates/contact_input.pt:8
-msgid "Choose a filter:"
-msgstr "Choisissez un filtre:"
 
 #: ../factory.py:36
 msgid "Contact"
@@ -29,10 +25,9 @@ msgstr "Contact"
 
 #: ../interfaces.py:34
 msgid "Contact content types that should be provided by autocompletion"
-msgstr ""
-"Types de contenus contact qui peuvent être proposés par l'autocomplétion"
+msgstr "Types de contenus contact qui peuvent être proposés par l'autocomplétion"
 
-#: ../factory.py:37
+#: ../factory.py:38
 msgid "Contact list"
 msgstr "Liste de contacts"
 
@@ -40,14 +35,17 @@ msgstr "Liste de contacts"
 msgid "Contact types"
 msgstr "Types de contacts"
 
-#: ../widgets.py:94
+#: ../widgets.py:136
 msgid "Fill your search here..."
 msgstr "Saisissez votre recherche..."
 
+#: ../templates/contact_input.pt:8
+msgid "Filter:"
+msgstr "Filtre:"
 
-#: ../templates/contact_input.pt:10
-msgid "No filter"
-msgstr "Aucun filtre"
+#: ../configure.zcml:22
+msgid "Installs the collective.contact.widget package"
+msgstr "Installe le module collective.contact.widget"
 
 #: ../interfaces.py:43
 msgid "Review states"
@@ -57,11 +55,10 @@ msgstr "États de workflow"
 msgid "Review states that should be visible"
 msgstr "États de workflow qui doivent être visibles"
 
-#. Default: "If the item doesn't exist, you can add it to the database :"
-#: ../templates/contact_input.pt:17
-msgid "help_widget_add_new_elt"
-msgstr "Si l'élément n'existe pas, vous pouvez l'ajouter à la base :"
+#: ../configure.zcml:22
+msgid "collective.contact.widget"
+msgstr "collective.contact.widget"
 
-#: ../widgets.py:32
+#: ../widgets.py:49
 msgid "please wait"
 msgstr "veuillez patienter"

--- a/src/collective/contact/widget/locales/fr/LC_MESSAGES/collective.contact.widget.po
+++ b/src/collective/contact/widget/locales/fr/LC_MESSAGES/collective.contact.widget.po
@@ -19,7 +19,11 @@ msgstr ""
 msgid "(nothing)"
 msgstr "(aucune)"
 
-#: ../factory.py:35
+#: ../templates/contact_input.pt:8
+msgid "Choose a filter:"
+msgstr "Choisissez un filtre:"
+
+#: ../factory.py:36
 msgid "Contact"
 msgstr "Contact"
 
@@ -39,6 +43,11 @@ msgstr "Types de contacts"
 #: ../widgets.py:94
 msgid "Fill your search here..."
 msgstr "Saisissez votre recherche..."
+
+
+#: ../templates/contact_input.pt:10
+msgid "No filter"
+msgstr "Aucun filtre"
 
 #: ../interfaces.py:43
 msgid "Review states"

--- a/src/collective/contact/widget/schema.py
+++ b/src/collective/contact/widget/schema.py
@@ -10,6 +10,7 @@ class ContactList(RelationList):
     implements(IContactList)
     source_types = None
     review_state = None
+    prefilter_vocubulary = None
 
     def __init__(self, *args, **kwargs):
         self.addlink = kwargs.pop('addlink', True)
@@ -17,6 +18,8 @@ class ContactList(RelationList):
                                        self.source_types or None)
         self.review_state = kwargs.pop('review_state',
                                        self.review_state or None)
+        self.prefilter_vocubulary = kwargs.pop('prefilter_vocubulary',
+                                               self.prefilter_vocubulary or None)
         if not 'value_type' in kwargs:
             kwargs['value_type'] = ContactChoice(source_types=self.source_types,
                                                  review_state=self.review_state)

--- a/src/collective/contact/widget/schema.py
+++ b/src/collective/contact/widget/schema.py
@@ -23,7 +23,7 @@ class ContactList(RelationList):
                                                self.prefilter_vocabulary or None)
         self.prefilter_default_value = kwargs.pop('prefilter_default_value',
                                                   self.prefilter_default_value or None)
-        if not 'value_type' in kwargs:
+        if 'value_type' not in kwargs:
             kwargs['value_type'] = ContactChoice(source_types=self.source_types,
                                                  review_state=self.review_state)
 
@@ -46,6 +46,8 @@ class ContactChoice(RelationChoice):
     implements(IContactChoice)
     source_types = None
     review_state = None
+    prefilter_vocabulary = None
+    prefilter_default_value = None  # context-aware function
 
     def __init__(self, slave_fields=(), *args, **kwargs):
         self.slave_fields = slave_fields
@@ -54,6 +56,10 @@ class ContactChoice(RelationChoice):
                                        self.source_types or None)
         self.review_state = kwargs.pop('review_state',
                                        self.review_state or None)
+        self.prefilter_vocabulary = kwargs.pop('prefilter_vocabulary',
+                                               self.prefilter_vocabulary or None)
+        self.prefilter_default_value = kwargs.pop('prefilter_default_value',
+                                                  self.prefilter_default_value or None)
         if not ('values' in kwargs or 'vocabulary' in kwargs or 'source' in kwargs):
             kwargs['source'] = ContactSourceBinder(
                 review_state=self.review_state,

--- a/src/collective/contact/widget/schema.py
+++ b/src/collective/contact/widget/schema.py
@@ -10,7 +10,7 @@ class ContactList(RelationList):
     implements(IContactList)
     source_types = None
     review_state = None
-    prefilter_vocubulary = None
+    prefilter_vocabulary = None
 
     def __init__(self, *args, **kwargs):
         self.addlink = kwargs.pop('addlink', True)
@@ -18,8 +18,8 @@ class ContactList(RelationList):
                                        self.source_types or None)
         self.review_state = kwargs.pop('review_state',
                                        self.review_state or None)
-        self.prefilter_vocubulary = kwargs.pop('prefilter_vocubulary',
-                                               self.prefilter_vocubulary or None)
+        self.prefilter_vocabulary = kwargs.pop('prefilter_vocabulary',
+                                               self.prefilter_vocabulary or None)
         if not 'value_type' in kwargs:
             kwargs['value_type'] = ContactChoice(source_types=self.source_types,
                                                  review_state=self.review_state)

--- a/src/collective/contact/widget/schema.py
+++ b/src/collective/contact/widget/schema.py
@@ -11,6 +11,7 @@ class ContactList(RelationList):
     source_types = None
     review_state = None
     prefilter_vocabulary = None
+    prefilter_default_value = None  # context-aware function
 
     def __init__(self, *args, **kwargs):
         self.addlink = kwargs.pop('addlink', True)
@@ -20,6 +21,8 @@ class ContactList(RelationList):
                                        self.review_state or None)
         self.prefilter_vocabulary = kwargs.pop('prefilter_vocabulary',
                                                self.prefilter_vocabulary or None)
+        self.prefilter_default_value = kwargs.pop('prefilter_default_value',
+                                                  self.prefilter_default_value or None)
         if not 'value_type' in kwargs:
             kwargs['value_type'] = ContactChoice(source_types=self.source_types,
                                                  review_state=self.review_state)

--- a/src/collective/contact/widget/source.py
+++ b/src/collective/contact/widget/source.py
@@ -104,7 +104,7 @@ class ContactSource(ObjPathSource):
     def tokenToUrl(self, token):
         return token.replace(self.portal_path, self.portal_url, 1)
 
-    def search(self, query, relations=None, limit=50):
+    def search(self, query, relations=None, limit=50, prefilter=None):
         """Copy from plone.formwidget.contenttree.source,
         to be able to use a modified version of parse_query.
         """
@@ -119,6 +119,9 @@ class ContactSource(ObjPathSource):
         if self.relations:
             # we apply limit after restriction on relations
             limit = catalog_query.pop('sort_limit', limit)
+
+        if prefilter:
+            catalog_query.update(prefilter)
 
         try:
             if 'sort_limit' in catalog_query:  # must limit results because solr sends None for higher limit results

--- a/src/collective/contact/widget/templates/contact_input.pt
+++ b/src/collective/contact/widget/templates/contact_input.pt
@@ -3,7 +3,7 @@
              xmlns:metal="http://xml.zope.org/namespaces/metal"
              xmlns:i18n="http://xml.zope.org/namespaces/i18n">
     <div tal:attributes="id string:${view/id}-autocomplete">
-        <div tal:define="voc view/field/prefilter_vocubulary"
+        <div tal:define="voc view/field/prefilter_vocabulary"
              tal:condition="voc">
             <label for="prefilter-select" i18n:translate="">Choose a filter:</label>
             <select name="prefilters" id="prefilter-select">

--- a/src/collective/contact/widget/templates/contact_input.pt
+++ b/src/collective/contact/widget/templates/contact_input.pt
@@ -5,11 +5,13 @@
     <div tal:attributes="id string:${view/id}-autocomplete">
         <div tal:define="voc view/prefilter_terms"
              tal:condition="voc">
-            <label for="prefilter-select" i18n:translate="">Choose a filter:</label>
-            <select name="prefilters" id="prefilter-select">
-                <option value="" i18n:translate="">No filter</option>
+            <select tal:define="default_value view/prefilter_default_value"
+                    name="prefilters" id="prefilter-select">
                 <tal:loop tal:repeat="term voc">
-                <option tal:attributes="value term/value" tal:content="term/title"></option>
+                <option tal:condition="python: term.value == default_value" tal:attributes="value term/value"
+                        tal:content="term/title" selected="selected"></option>
+                <option tal:condition="python: term.value != default_value" tal:attributes="value term/value"
+                        tal:content="term/title"></option>
                 </tal:loop>
             </select>
         </div>

--- a/src/collective/contact/widget/templates/contact_input.pt
+++ b/src/collective/contact/widget/templates/contact_input.pt
@@ -7,7 +7,7 @@
              tal:condition="voc">
             <label for="prefilter-select" i18n:translate="">Filter:</label>
             <select tal:define="default_value view/prefilter_default_value"
-                    name="prefilters" id="prefilter-select">
+                    name="prefilters" class="prefilter-select">
                 <tal:loop tal:repeat="term voc">
                 <option tal:attributes="value term/value; selected python: term.value == default_value"
                         tal:content="term/title"></option>

--- a/src/collective/contact/widget/templates/contact_input.pt
+++ b/src/collective/contact/widget/templates/contact_input.pt
@@ -3,7 +3,7 @@
              xmlns:metal="http://xml.zope.org/namespaces/metal"
              xmlns:i18n="http://xml.zope.org/namespaces/i18n">
     <div tal:attributes="id string:${view/id}-autocomplete">
-        <div tal:define="voc view/field/prefilter_vocabulary"
+        <div tal:define="voc view/prefilter_terms"
              tal:condition="voc">
             <label for="prefilter-select" i18n:translate="">Choose a filter:</label>
             <select name="prefilters" id="prefilter-select">

--- a/src/collective/contact/widget/templates/contact_input.pt
+++ b/src/collective/contact/widget/templates/contact_input.pt
@@ -5,12 +5,11 @@
     <div tal:attributes="id string:${view/id}-autocomplete">
         <div tal:define="voc view/prefilter_terms"
              tal:condition="voc">
+            <label for="prefilter-select" i18n:translate="">Filter:</label>
             <select tal:define="default_value view/prefilter_default_value"
                     name="prefilters" id="prefilter-select">
                 <tal:loop tal:repeat="term voc">
-                <option tal:condition="python: term.value == default_value" tal:attributes="value term/value"
-                        tal:content="term/title" selected="selected"></option>
-                <option tal:condition="python: term.value != default_value" tal:attributes="value term/value"
+                <option tal:attributes="value term/value; selected python: term.value == default_value"
                         tal:content="term/title"></option>
                 </tal:loop>
             </select>

--- a/src/collective/contact/widget/templates/contact_input.pt
+++ b/src/collective/contact/widget/templates/contact_input.pt
@@ -3,6 +3,16 @@
              xmlns:metal="http://xml.zope.org/namespaces/metal"
              xmlns:i18n="http://xml.zope.org/namespaces/i18n">
     <div tal:attributes="id string:${view/id}-autocomplete">
+        <div tal:define="voc view/field/prefilter_vocubulary"
+             tal:condition="voc">
+            <label for="prefilter-select" i18n:translate="">Choose a filter:</label>
+            <select name="prefilters" id="prefilter-select">
+                <option value="" i18n:translate="">No filter</option>
+                <tal:loop tal:repeat="term voc">
+                <option tal:attributes="value term/value" tal:content="term/title"></option>
+                </tal:loop>
+            </select>
+        </div>
         <div tal:attributes="id string:${view/id}-input-fields" class="autocompleteInputWidget"
              tal:content="structure view/renderQueryWidget">
         </div>

--- a/src/collective/contact/widget/widgets.py
+++ b/src/collective/contact/widget/widgets.py
@@ -112,7 +112,7 @@ class ContactBaseWidget(object):
                 formatItem: %(formatItem)s,
                 formatResult: %(formatResult)s,
                 parse: %(parseFunction)s,
-                extraParams: {'prefilter': function() {return $('#prefilter-select').val() || '';}}
+                extraParams: {'prefilter': function() {return $('#formfield-%(id)s .prefilter-select').val() || '';}}
             }).result(%(js_callback)s);
             %(js_extra)s
         });

--- a/src/collective/contact/widget/widgets.py
+++ b/src/collective/contact/widget/widgets.py
@@ -8,6 +8,9 @@ from zope.component.interfaces import ComponentLookupError
 from zope.i18n import translate
 from zope.interface import implementer, implements, Interface
 from zope.browserpage.viewpagetemplatefile import ViewPageTemplateFile
+from zope.schema.interfaces import IContextSourceBinder
+from zope.schema.interfaces import IVocabulary
+from zope.schema.interfaces import IVocabularyFactory
 from five import grok
 
 from Products.CMFPlone.utils import base_hasattr, safe_unicode
@@ -17,6 +20,7 @@ from plone.formwidget.autocomplete.widget import (
     AutocompleteMultiSelectionWidget,
     AutocompleteSelectionWidget)
 from plone.formwidget.autocomplete.widget import AutocompleteSearch as BaseAutocompleteSearch
+
 try:
     from plone.formwidget.masterselect.widget import MasterSelect as BaseMasterSelect
     from plone.formwidget.masterselect.interfaces import IMasterSelectWidget
@@ -181,6 +185,18 @@ function (event, data, formatted) {
                 closeOnClick=self.close_on_click and 'true' or 'false'))
 
         return content
+
+    def prefilter_terms(self):
+        if isinstance(self.field.prefilter_vocabulary, basestring):
+            vocabulary = getUtility(IVocabularyFactory, name=self.field.prefilter_vocabulary)
+            return vocabulary(self.context)
+        elif IVocabulary.providedBy(self.field.prefilter_vocabulary):
+            return self.field.prefilter_vocabulary
+        elif IContextSourceBinder.providedBy(self.field.prefilter_vocabulary):
+            source = self.field.prefilter_vocabulary
+            return source(self.context)
+        else:
+            return []
 
 
 class ContactAutocompleteSelectionWidget(ContactBaseWidget, AutocompleteSelectionWidget, MasterSelect):

--- a/src/collective/contact/widget/widgets.py
+++ b/src/collective/contact/widget/widgets.py
@@ -198,6 +198,12 @@ function (event, data, formatted) {
         else:
             return []
 
+    def prefilter_default_value(self):
+        if callable(self.field.prefilter_default_value):
+            return self.field.prefilter_default_value(self.context)
+        else:
+            return None
+
 
 class ContactAutocompleteSelectionWidget(ContactBaseWidget, AutocompleteSelectionWidget, MasterSelect):
     implements(IContactAutocompleteSelectionWidget)

--- a/src/collective/contact/widget/widgets.py
+++ b/src/collective/contact/widget/widgets.py
@@ -1,3 +1,5 @@
+import json
+
 from z3c.form.interfaces import IFieldWidget
 import z3c.form.interfaces
 from z3c.form.widget import FieldWidget
@@ -105,7 +107,8 @@ class ContactBaseWidget(object):
                 matchSubset: false,
                 formatItem: %(formatItem)s,
                 formatResult: %(formatResult)s,
-                parse: %(parseFunction)s
+                parse: %(parseFunction)s,
+                extraParams: {'prefilter': function() {return $('#prefilter-select').val() || '';}}
             }).result(%(js_callback)s);
             %(js_extra)s
         });
@@ -226,7 +229,16 @@ class AutocompleteSearch(BaseAutocompleteSearch):
             query = "path:%s %s" % (source.tokenToPath(path), query)
 
         if query or relations:
-            terms = source.search(query, relations=relations)
+            prefilter = {}
+            try:
+                prefilter_param = json.loads(self.request.get('prefilter'))
+                if type(prefilter_param) == dict and len(prefilter_param) > 0:
+                    prefilter = prefilter_param
+            except ValueError:
+                pass
+
+            terms = source.search(query, relations=relations, prefilter=prefilter)
+
         else:
             terms = ()
 


### PR DESCRIPTION
This commit adds an optional prefiltering to the ContactList widget.

The available filters are expressed by a vocabulary, set as a widget attribute.
Its values must be JSON representation of catalog query parameters.

When the user types a query, any selected filter is sent by autocomplete as an extra parameter, which is then used in the catalog search.

proof of concept:

```python
prefilters_vocabulary = SimpleVocabulary(
    [
        SimpleTerm(value=u'{"email":"fred.agent@macommune.be"}', title=_(u'Email is fred.agent@macommune.be')),
    ]
)

class IMyIncomingMail(IDmsIncomingMail):

    sender = ContactList(
        title=_(u'Sender'),
        required=True,
        value_type=ContactChoice(
            source=DmsContactSourceBinder(portal_type=("organization", 'held_position', 'person', 'contact_list'),
                                          review_state=['active'],
                                          sort_on='sortable_title')
        ),
        prefilter_vocubulary=prefilters_vocabulary,
    )
```